### PR TITLE
Fix SettingsScope imported from binaryninja

### DIFF
--- a/ethersplay/evm.py
+++ b/ethersplay/evm.py
@@ -440,7 +440,7 @@ class EVMView(BinaryView):
             'analysis.linearSweep.autorun',
             False,
             view=self,
-            scope=SettingsScope.SettingsContextScope
+            scope=SettingsScope.SettingsResourceScope
         )
 
         return True


### PR DESCRIPTION
`SettingsScope.SettingsContextScope` is used in `evm.py` line 443

This setting is no longer available in [binaryninja api](https://api.binary.ninja/)

This commit updates the `SettingsScope` to use `SettingsResourceScope`

Fixes https://github.com/crytic/ethersplay/issues/49