### PR TITLE
Update maxFunctionSize Setting

### DIFF
--- a/ethersplay/analysis.py
+++ b/ethersplay/analysis.py
@@ -66,7 +66,7 @@ def run_vsa(thread, view, function):
 
     if function.start == 0:
         max_function_size, _ = Settings().get_integer_with_scope(
-            'analysis.maxFunctionSize', scope=SettingsScope.SettingsDefaultScope)
+            'analysis.limits.maxFunctionSize', scope=SettingsScope.SettingsDefaultScope)
         if max_function_size:
             view.max_function_size_for_analysis = max_function_size
         else:


### PR DESCRIPTION
Setting 'analysis.maxFunctionSize' is deprecated by 'analysis.limits.maxFunctionSize'.

This pull request updates `analysis.py` to use the new value.

Fixes #51 